### PR TITLE
fixed node6.2.1 install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/stevetarver/excel-as-json",
   "dependencies": {
-    "excel": "0.1.5"
+    "excel": "^0.1.6"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
when using excel0.15, it downloads libxml 0.14.3, a bug with node6.0, so try to use excel 0.16, everything is fine.

You work is awesome. I like your project. so Please fix this problem.